### PR TITLE
Safety check to make sure the MSP payment URL arrived

### DIFF
--- a/resources/js/multisafepay.js
+++ b/resources/js/multisafepay.js
@@ -8,8 +8,17 @@ document.addEventListener('turbo:load', () => {
         }
         window.app.checkout.doNotGoToTheNextStep = true
         let cart = window.app.user ? 'mine' : localStorage.mask;
-        magentoUser.get(`/multisafepay/${cart}/payment-url/${data.order.id}`).then(response => {
-            window.location.replace(response.data);
-        });
+
+        let waitForURL = function(cartId, orderId) {
+            magentoUser.get(`/multisafepay/${cartId}/payment-url/${orderId}`).then(response => {
+                if(response.data) {
+                    window.location.replace(response.data);
+                } else {
+                    window.setTimeout(() => waitForURL(cartId, orderId), 1000);
+                }
+            });
+        }
+
+        waitForURL(cart, data.order.id);
     });
 })


### PR DESCRIPTION
It's hard to debug whether or not this is actually caused by MSP responding late or not, because this seems to be rare.

Note: It appears that the payment link *never* arrives if the used order number already exists somewhere within the used multisafepay account. This should only be an issue for development purposes however.