### PR TITLE
Set token and mask again when showing checkoutsuccess

### DIFF
--- a/resources/js/components/MSPPending.vue
+++ b/resources/js/components/MSPPending.vue
@@ -28,8 +28,6 @@
 
         render() {
             return this.$scopedSlots.default({
-                token: this.token,
-                mask: this.mask,
                 completed: this.completed,
                 order: this.order
             })
@@ -48,7 +46,7 @@
                     if(['processing', 'success', 'complete'].includes(response.data?.status)) {
                         useToken.value = this.token;
                         useMask.value = this.mask;
-                        
+
                         this.completed = true;
                         this.order = Object.assign({
                             sales_order_items: response.data.items,

--- a/resources/js/components/MSPPending.vue
+++ b/resources/js/components/MSPPending.vue
@@ -1,5 +1,19 @@
 <script>
+    import { mask as useMask } from 'Vendor/rapidez/core/resources/js/stores/useMask'
+    import { token as useToken } from 'Vendor/rapidez/core/resources/js/stores/useUser'
+
     export default {
+        props: {
+            token: {
+                type: String,
+                default: useToken.value,
+            },
+            mask: {
+                type: String,
+                default: useMask.value,
+            },
+        },
+
         data() {
             return {
                 completed: false,
@@ -14,6 +28,8 @@
 
         render() {
             return this.$scopedSlots.default({
+                token: this.token,
+                mask: this.mask,
                 completed: this.completed,
                 order: this.order
             })
@@ -30,6 +46,9 @@
 
                 magento.get(`/multisafepay/orders/${orderId}/${token}`).then(response => {
                     if(['processing', 'success', 'complete'].includes(response.data?.status)) {
+                        useToken.value = this.token;
+                        useMask.value = this.mask;
+                        
                         this.completed = true;
                         this.order = Object.assign({
                             sales_order_items: response.data.items,


### PR DESCRIPTION
1.x only since we're using useMask & useUser

Since the pending page does not refresh the page Rapidez will attempt to refresh the cart after ~5 seconds.
Multisafepay is not fast enough so after these 5 seconds Rapidez realises the cart is no longer valid and removes the mask causing an empty success page.

This ensures the mask and token do exist when rendering the success component so we can fetch the order.