### PR TITLE
[2.x] Remove extra /

### DIFF
--- a/resources/js/components/MSPPending.vue
+++ b/resources/js/components/MSPPending.vue
@@ -42,7 +42,7 @@
                     return;
                 }
 
-                window.magentoAPI('get', `/multisafepay/orders/${orderId}/${token}`).then(response => {
+                window.magentoAPI('get', `multisafepay/orders/${orderId}/${token}`).then(response => {
                     if(['processing', 'success', 'complete'].includes(response?.status)) {
                         useToken.value = this.token;
                         useMask.value = this.mask;


### PR DESCRIPTION
This request would go to `[...]/V1//multisafepay` which doesn't work.

Maybe it would be a good addition to the core to filter out double slashes like that automatically? I don't really know if there would be any situation where you want a double slash in your url.