### PR TITLE
Proxy notification url instead of redirecting

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Route;
 
 Route::middleware('web')->group(function () {
@@ -16,6 +17,21 @@ Route::middleware('web')->group(function () {
 
         return redirect('cart');
     })->name('multisafepay.cancel');
+
+    // Multisafepay does not follow redirects for the notification url
+    Route::any('multisafepay/connect/notification', function (Request $request): \Psr\Http\Message\ResponseInterface {
+        $url = rtrim(config('rapidez.magento_url'), '/') . $request->getRequestUri();
+
+        return Http::withHeaders([
+            'X-Real-IP' => $request->ip(),
+            'X-Forwarded-For' => $request->header('X-Forwarded-For', $request->ip()),
+        ])
+            ->send($request->method(), $url, [
+                'query' => $request->query(),
+                'json' => $request->json(),
+            ])
+            ->toPsrResponse();
+    });
 });
 
 // Return multisafepay connect requests back to Magento.


### PR DESCRIPTION
Multisafepay no longer follows redirects for the notification url, this proxies the request instead