### PR TITLE
[5.x] Fix error on null id

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -12,7 +12,7 @@ Route::middleware('web')->group(function () {
     Route::get('/msp-return/cancel', function(Request $request) {
         config('rapidez.models.quote')::query()
             ->withoutGlobalScopes()
-            ->whereQuoteIdOrCustomerToken($request->input('quoteId'))
+            ->whereQuoteIdOrCustomerToken($request->input('quoteId', ''))
             ->update(['is_active' => 1]);
 
         return redirect('cart');


### PR DESCRIPTION
We got an error when someone directly navigated to `/msp-return/cancel`. This fixes that by giving a default empty string.